### PR TITLE
feat: add change data capture triggers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,16 @@
 ## Security & Configuration Tips
 - Configure `VKA_DATABASE` with a non-production DSN during development. Do not commit secrets.
 - Snapshot/restore operations can be destructive; test against disposable databases.
+
+## Change Data Capture & Branch Workflow
+1. Ensure a PostgreSQL server is running and that the Postgres data directory is reachable. Export:
+   - `VKA_DATABASE` to the target DSN.
+   - `VKA_PG_DATA_PATH` to the server's data directory.
+   - `VKA_NOCOW=1` when copy-on-write is unavailable.
+2. Create a source database with application tables.
+3. Run `uv run vkarious branch <source_db> <branch_name>`.
+   - The CLI registers the source, installs change-capture triggers, creates the branch, copies data files, fixes ownership, and installs change-capture on the branch.
+4. Verify triggers with:
+   - `SELECT tgname FROM pg_trigger WHERE tgname LIKE 'vka_%';`
+   - Insert rows into tables and check captured rows in `vka_cdc`.
+5. Consult `design-doc.md` for details on triggers and the capture function.

--- a/design-doc.md
+++ b/design-doc.md
@@ -1,0 +1,36 @@
+# Change Capture Design
+
+## Overview
+vkarious installs change data capture (CDC) on each database that participates in branching. CDC uses a trigger-driven log table to record row-level changes.
+
+## Components
+- **vka_cdc table** – stores change events with columns:
+  - `id` bigserial primary key
+  - `table_name` text
+  - `operation` text (INSERT, UPDATE, DELETE)
+  - `data` jsonb (row payload)
+  - `changed_at` timestamptz default `now()`
+- **vka_capture() function** – PL/pgSQL trigger function inserting row changes into `vka_cdc`. It records `OLD` on DELETE and `NEW` for INSERT/UPDATE.
+- **Triggers** – for every user table in the `public` schema, a trigger named `vka_<table>_cdc` is created:
+  - Fires AFTER INSERT, UPDATE, or DELETE
+  - Invokes `vka_capture()`
+  - The installer skips the `vka_cdc` table and removes any accidental trigger on it to avoid recursion.
+
+## Installation Flow
+1. Determine DSN from `VKA_DATABASE` and connect to the target database.
+2. Create `vka_cdc` and `vka_capture()` if missing.
+3. Enumerate `pg_tables` in `public` and create missing triggers.
+4. Re-run installer to update triggers when new tables appear.
+
+## Branch Interaction
+During `vkarious branch`:
+1. Register source in metadata and ensure change capture on source.
+2. Create branch database using `STRATEGY='FILE_COPY'`.
+3. Copy physical files and reset ownership to `postgres:postgres`.
+4. Install change capture on the new branch.
+5. Insert operations on either database are logged in their respective `vka_cdc` tables.
+
+## Verifying CDC
+- Inspect triggers: `SELECT tgname FROM pg_trigger WHERE tgname LIKE 'vka_%';`
+- Inspect captured rows: `SELECT * FROM vka_cdc;`
+- Reset log: `TRUNCATE vka_cdc;`

--- a/src/vkarious/change_capture.py
+++ b/src/vkarious/change_capture.py
@@ -1,0 +1,95 @@
+"""Change data capture trigger installation for vkarious."""
+
+from __future__ import annotations
+
+import psycopg
+
+from .db import get_database_dsn
+
+
+class ChangeCaptureInstaller:
+    """Install triggers to capture table changes."""
+
+    def ensure_installed(self, database_name: str) -> bool:
+        """Ensure change capture is installed on the given database.
+
+        Returns True when any installation actions were performed.
+        Returns False when everything was already present.
+        """
+        dsn = get_database_dsn()
+        params = psycopg.conninfo.conninfo_to_dict(dsn)
+        params["dbname"] = database_name
+        target_dsn = psycopg.conninfo.make_conninfo(**params)
+
+        installed = False
+
+        with psycopg.connect(target_dsn) as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT to_regclass('public.vka_cdc')")
+                result = cur.fetchone()
+                table_exists = result[0] is not None
+                if not table_exists:
+                    cur.execute(
+                        """
+                        CREATE TABLE vka_cdc (
+                            id BIGSERIAL PRIMARY KEY,
+                            table_name TEXT,
+                            operation TEXT,
+                            data JSONB,
+                            changed_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+                        )
+                        """
+                    )
+                    cur.execute(
+                        """
+                        CREATE OR REPLACE FUNCTION vka_capture() RETURNS trigger AS $$
+                        BEGIN
+                            IF TG_OP = 'DELETE' THEN
+                                INSERT INTO vka_cdc(table_name, operation, data)
+                                    VALUES (TG_TABLE_NAME, TG_OP, row_to_json(OLD));
+                                RETURN OLD;
+                            ELSE
+                                INSERT INTO vka_cdc(table_name, operation, data)
+                                    VALUES (TG_TABLE_NAME, TG_OP, row_to_json(NEW));
+                                RETURN NEW;
+                            END IF;
+                        END;
+                        $$ LANGUAGE plpgsql
+                        """
+                    )
+                    installed = True
+
+                cur.execute(
+                    """
+                    SELECT tablename
+                    FROM pg_tables
+                    WHERE schemaname = 'public'
+                    """
+                )
+                tables = cur.fetchall()
+                index = 0
+                while index < len(tables):
+                    table_name = tables[index][0]
+                    if table_name == "vka_cdc":
+                        cur.execute(
+                            "DROP TRIGGER IF EXISTS vka_vka_cdc_cdc ON vka_cdc"
+                        )
+                        index = index + 1
+                        continue
+                    trigger_name = f"vka_{table_name}_cdc"
+                    cur.execute(
+                        "SELECT 1 FROM pg_trigger WHERE tgname = %s", (trigger_name,)
+                    )
+                    trigger_row = cur.fetchone()
+                    if trigger_row is None:
+                        cur.execute(
+                            f"""
+                            CREATE TRIGGER {trigger_name}
+                            AFTER INSERT OR UPDATE OR DELETE ON {table_name}
+                            FOR EACH ROW EXECUTE FUNCTION vka_capture()
+                            """
+                        )
+                        installed = True
+                    index = index + 1
+            conn.commit()
+        return installed

--- a/src/vkarious/db.py
+++ b/src/vkarious/db.py
@@ -199,6 +199,13 @@ def copy_database_files(data_directory: str, source_oid: int, target_oid: int) -
             )
         else:
             raise
+
+    subprocess.run(
+        ["chown", "-R", "postgres:postgres", str(target_path)],
+        check=True,
+        capture_output=True,
+        text=True
+    )
     
     # Remove pg_internal.init file from the copied directory
     pg_internal_init = target_path / "pg_internal.init"


### PR DESCRIPTION
## Summary
- implement ChangeCaptureInstaller to create vka_cdc log and table triggers
- ensure branch copy sets postgres ownership
- document CDC workflow and add design doc

## Testing
- `uv run vkarious branch source_db branch1`
- `sudo -u postgres psql -h /tmp -p 5544 -d source_db -c "SELECT tgname FROM pg_trigger WHERE tgname LIKE 'vka_%';"`
- `sudo -u postgres psql -h /tmp -p 5544 -d branch1 -c "SELECT tgname FROM pg_trigger WHERE tgname LIKE 'vka_%';"`
- `sudo -u postgres psql -h /tmp -p 5544 -d source_db -c "TRUNCATE vka_cdc;" && sudo -u postgres psql -h /tmp -p 5544 -d source_db -c "INSERT INTO items (name) VALUES ('alpha');" && sudo -u postgres psql -h /tmp -p 5544 -d source_db -c "SELECT table_name, operation, data->>'name' AS name FROM vka_cdc;"`
- `sudo -u postgres psql -h /tmp -p 5544 -d branch1 -c "TRUNCATE vka_cdc;" && sudo -u postgres psql -h /tmp -p 5544 -d branch1 -c "INSERT INTO items (name) VALUES ('beta');" && sudo -u postgres psql -h /tmp -p 5544 -d branch1 -c "SELECT table_name, operation, data->>'name' AS name FROM vka_cdc;"`
- `uv run pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg')*

------
https://chatgpt.com/codex/tasks/task_e_68bc42b08cbc832fb24f920eb327bc2f