### PR TITLE
docs: document DDL integration tests and remaining gaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,12 @@
 ## Security & Configuration Tips
 - Configure `VKA_DATABASE` with a non-production DSN during development. Do not commit secrets.
 - Snapshot/restore operations can be destructive; test against disposable databases.
+
+## Integration Tests
+- Ensure PostgreSQL is running locally and accessible via a DSN.
+- Create a virtual environment and install dependencies:
+  - `uv venv --python /usr/bin/python3`
+  - `uv pip install -e . pytest`
+- Export a DSN for tests, e.g. `export VKA_DATABASE="postgresql:///postgres"`.
+- Run the DDL logging tests (using peer auth by invoking as the `postgres` user):
+  - `sudo -u postgres VKA_DATABASE=$VKA_DATABASE uv run pytest tests/test_ddl_integration.py -q`

--- a/remaining-ddl.md
+++ b/remaining-ddl.md
@@ -1,0 +1,39 @@
+# Remaining DDL Gaps
+
+This document lists DDL operations that the current capture system does not record with full fidelity.
+
+## Alter Table lacks full context
+The audit stores the raw `ALTER TABLE` statement but omits the resulting table definition. Column renames or constraint changes therefore lack before/after details.
+
+*Example*
+```sql
+ALTER TABLE users ADD CONSTRAINT users_email_key UNIQUE (email);
+```
+Only the above statement is logged; the new table structure is not.
+
+## Drops for non-table objects
+`sql_drop` triggers are limited to table-like objects. Dropping views, functions, or sequences does not create a `ddl_log` entry.
+
+*Example*
+```sql
+DROP VIEW recent_orders;
+```
+No row is recorded.
+
+## Unsupported object types
+Operations such as `CREATE SCHEMA`, `ALTER SEQUENCE`, or `CREATE TYPE` are ignored by the DDL audit.
+
+*Example*
+```sql
+ALTER SEQUENCE order_id_seq RESTART WITH 1000;
+```
+This command is not captured.
+
+## Dynamic DDL via EXECUTE
+Event triggers do not see dynamically generated DDL executed through `EXECUTE`, leaving the log empty for those statements.
+
+*Example*
+```sql
+EXECUTE format('ALTER TABLE %I ADD COLUMN %I int', tab, col);
+```
+


### PR DESCRIPTION
## Summary
- describe how to run DDL integration tests with PostgreSQL
- list DDL operations that remain unlogged in `remaining-ddl.md`

## Testing
- `sudo -u postgres VKA_DATABASE="postgresql:///postgres" uv run pytest tests/test_ddl_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd93f688dc832f91513968021271c8